### PR TITLE
New commands : --read for individual ROMs, --dump and --restore + update doc

### DIFF
--- a/50_ems_gb_flash.rules
+++ b/50_ems_gb_flash.rules
@@ -1,0 +1,3 @@
+# EMS USB 64M Gameboy flash cart
+SUBSYSTEM=="usb", ACTION=="add", ATTRS{idVendor}=="4670", \
+  ATTRS{idProduct}=="9394", TAG+="uaccess"

--- a/Makefile.tmpl
+++ b/Makefile.tmpl
@@ -1,4 +1,5 @@
 MENUVARS = menu.gb menucs.gb menuc.gb menus.gb
+UDEVRULES = 50_ems_gb_flash.rules
 
 PROG = ems-flasher-real
 OBJS = ems.o main.o header.o cmd.o updates.o progress.o flash.o insert.o \
@@ -69,7 +70,13 @@ menu: FORCE
 test: FORCE ems-flasher
 	cd tests && make test
 
-install: $(PROG) menuvars
+install-udevrules:
+	@if test -n '$(UDEVRULESDIR)'; then \
+	    cp '$(UDEVRULES)' '$(UDEVRULESDIR)' && \
+	    udevadm control --reload-rules; \
+        fi
+
+install: $(PROG) menuvars install-udevrules
 	mkdir -p $(BINDIR)
 	install ems-flasher-real "$(BINDIR)"/ems-flasher
 	mkdir -p "$(DATADIR)"

--- a/README.md
+++ b/README.md
@@ -68,31 +68,38 @@ The software has four major modes of operation:
   * delete ROMs
 
 To write use --write, to read use --read, and to get the title listing use
---title. You can specify the page (1 or 2) with --bank PAGENB. If no page is
+--title. You can specify the page (1 or 2) with --page PAGENB. If no page is
 specified, page 1 is assumed.
 
-Write mode will write the ROM files specified on the command line to 
-the selected page to the cart. Read mode will read the entirety of the page
-(32 megabits / 4 megabytes) into the ROM file specified. Specifying multiple
-ROMs will cause all of the ROMs to be written to the specified bank along with a
-menu to choose from them. Some ROMs support enhancements of the Super Game Boy
-or the Game Boy Color or both. For maximum compatibility, you shouldn't mix ROMs
-with different enhancements support on the same page. However, if you don't
-intend to use a Super Game Boy or a Game Boy Color, you can mix ROMs that
-support, resp., SGB or CGB enhancements with others that don't with the --force
-option. This option is not necessary if the page already contains mixed ROMs.
+Write mode will write the ROM files specified on the command line to the
+selected page to the cart. Specifying multiple ROMs will cause all of the ROMs
+to be written to the specified page along with a menu to choose from them.
+If you intend to use the card on a Super Game Boy or a Game Boy Color, you
+should isolate, resp., the Super Game Boy ROMs or the Game Boy Color ROMS on a
+same page and put the other ROMs on the other page. E.g., if you own a Game Boy
+Color, you could put all the Game Boy Color ROMs in page 1 and the Super Game
+Boy and Classic Game Boy ROMs in the other. Use --force to write ROMs from
+different models on the same page. This option is not necessary if the page
+already contains mixed ROMs.
 
-Title mode does not require a file argument, and will print the ROM
-title listing to stdout.
+Read mode will read the ROMs specified on the command line from the specified
+page into files. ROMs are identified by the number of their first bank as
+printed by the --title command.
+
+It is also possible to backup an entire flash page or the Save RAM to a file
+with the --dump command. The command --restore can be used to restore an image
+taken with --dump back to the card. If these commands must apply on the Save
+RAM, use the --save option or end the filename by ".sav". Note that the Save
+RAM is not paged.
+
+Title mode does not require a file argument, and will print the ROM title
+listing to stdout.
 
 The --delete command will delete the ROMs whose bank numbers are specified in
-parmeters.
+parameters.
 The --format command will delete all the ROMs located on the chosen page.
 
 Additionally, all modes take a --verbose flag for giving more output.
-You can also adjust the block size, but it is recommended you leave this
-to the default of 4096 bytes for writing and 32 bytes for reading (used
-by the Windows software).
 
 For a full list of options, run the command with the --help flag.
 
@@ -107,10 +114,10 @@ Examples
 ./ems-flasher --write totally_legit_rom.gb
 
 # write several ROMs to the cart
-./ems-flash --write copyright.gb infringement.gb
+./ems-flasher --write copyright.gb infringement.gb
 
 # saves the contents of the cart into the file; print some extra info
-./ems-flasher --verbose --read not_warez.gb
+./ems-flasher --verbose --dump not_warez.gb
 
 # print out the title
 ./ems-flasher --title
@@ -118,9 +125,6 @@ Examples
 
 Bugs
 ----
-
-In this version, the --read command dumps an entire page. It is not possible to
-dump a particular ROM.
 
 Preferably use the bug tracker found at the web site (at the top of this
 doc) to report any bugs.

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ sudo apt-get install pkg-config libusb-1.0-0-dev
 ```
 
 
-Building
---------
+Building and Installing
+-----------------------
 
 ```
 ./config.sh --prefix=/usr
@@ -58,76 +58,21 @@ build directory, it will use the menu ROMs located in the same directory, not
 the one selected with `config.sh` so you can use the software without
 installing it.
 
+On Linux, udev rules ensuring access to users to the USB device without
+requiring root privileges will be installed on make install.
+Use make install-udevrules to install only the rules, without the sofware.
+
 Running
 -------
 
-The software has four major modes of operation:
-  * write ROM(s) to cart
-  * read ROM from cart
-  * read title of ROM on cart
-  * delete ROMs
-
-To write use --write, to read use --read, and to get the title listing use
---title. You can specify the page (1 or 2) with --page PAGENB. If no page is
-specified, page 1 is assumed.
-
-Write mode will write the ROM files specified on the command line to the
-selected page to the cart. Specifying multiple ROMs will cause all of the ROMs
-to be written to the specified page along with a menu to choose from them.
-If you intend to use the card on a Super Game Boy or a Game Boy Color, you
-should isolate, resp., the Super Game Boy ROMs or the Game Boy Color ROMS on a
-same page and put the other ROMs on the other page. E.g., if you own a Game Boy
-Color, you could put all the Game Boy Color ROMs in page 1 and the Super Game
-Boy and Classic Game Boy ROMs in the other. Use --force to write ROMs from
-different models on the same page. This option is not necessary if the page
-already contains mixed ROMs.
-
-Read mode will read the ROMs specified on the command line from the specified
-page into files. ROMs are identified by the number of their first bank as
-printed by the --title command.
-
-It is also possible to backup an entire flash page or the Save RAM to a file
-with the --dump command. The command --restore can be used to restore an image
-taken with --dump back to the card. If these commands must apply on the Save
-RAM, use the --save option or end the filename by ".sav". Note that the Save
-RAM is not paged.
-
-Title mode does not require a file argument, and will print the ROM title
-listing to stdout.
-
-The --delete command will delete the ROMs whose bank numbers are specified in
-parameters.
-The --format command will delete all the ROMs located on the chosen page.
-
-Additionally, all modes take a --verbose flag for giving more output.
-
-For a full list of options, run the command with the --help flag.
-
-The MENUDIR environment variable may used to override the location of the menu
-ROMs selected by `config.sh`.
-
-Examples
---------
-
-```
-# write the ROM to the cart
-./ems-flasher --write totally_legit_rom.gb
-
-# write several ROMs to the cart
-./ems-flasher --write copyright.gb infringement.gb
-
-# saves the contents of the cart into the file; print some extra info
-./ems-flasher --verbose --dump not_warez.gb
-
-# print out the title
-./ems-flasher --title
-```
+Please consult the manual (ems-flasher(1)) for usage instructions.
+You can read the manual without installing it with: `man -l ./ems-flasher.1`.
 
 Bugs
 ----
 
-Preferably use the bug tracker found at the web site (at the top of this
-doc) to report any bugs.
+Preferably use the bug tracker on GitHub:
+   https://github.com/mikeryan/ems-flasher
 
 You can also send em to mikeryan \at lacklustre.net
 

--- a/cmd.c
+++ b/cmd.c
@@ -703,3 +703,92 @@ cmd_write(int page, int verbose, int force, int argc, char **argv) {
     exit(apply_updates(page, verbose, updates));
     }
 }
+
+void
+cmd_read(int page, int verbose, int argc, char **argv) {
+    struct listing  listing;
+    struct {struct listing_rom *rom; char *path;} *romfiles;
+    ems_size_t totalread;
+
+    if (argc == 0)
+	return;
+
+    blocksignals();
+
+    if (list(page, &listing))
+	exit(1);
+
+    if ((romfiles = malloc(argc * sizeof(*romfiles))) == NULL)
+	err(1, "malloc");
+
+    totalread = 0;
+
+    for (int i = 0; i < argc; i++) {
+	ems_size_t      offset;
+	char           *path, *p;
+	int             bank;
+
+	long l = strtol(argv[i], &p, 10);
+	if (p == argv[i] || *p != ':')
+	    errx(1, "invalid argument format (should be BANK:FILENAME)");
+
+	if (l < 0 || l > PAGESIZE / BANKSIZE) {
+	    errx(1, "bank must range between 0 and %d",
+		  (int) (PAGESIZE / BANKSIZE - 1));
+	}
+	bank = l;
+
+	offset = bank * BANKSIZE;
+	path = p + 1;
+	if (*path == '\0')
+	    errx(1, "invalid filename");
+
+	struct listing_rom *rom = NULL;
+	for (int i = 0; i < listing.count; i++) {
+	    if (listing.romlist[i].offset == offset) {
+		rom = &listing.romlist[i];
+		break;
+	    }
+	}
+	if (rom == NULL)
+	    errx(1, "No ROM found at bank %d", bank);
+
+	if (rom->header.romsize == 0 ||
+	    offset + rom->header.romsize > PAGESIZE) {
+	    errx(1, "invalid ROM");
+	}
+
+        if (totalread >=0 && totalread <= EMS_SIZE_MAX - rom->header.romsize)
+            totalread += rom->header.romsize;
+        else
+            totalread = -1;
+
+	romfiles[i].path = path;
+        romfiles[i].rom = rom;
+    }
+
+    catchint();
+
+    if (verbose && totalread > 0)
+        progress_start((struct progress_totals){.read = totalread});
+
+    for (int i = 0; i < argc; i++) {
+        struct listing_rom *rom = romfiles[i].rom;
+        char *path = romfiles[i].path;
+
+	if (verbose) {
+	    printf("Copying bank %d (%s) to %s\n", rom->offset/BANKSIZE,
+                   rom->header.title, path);
+	}
+
+	flash_init(verbose ? progress : NULL, checkint);
+
+	if (flash_readf_from(FROM_ROM, path, rom->header.romsize,
+			     page * PAGESIZE + rom->offset))
+	    errx(1, "%s", flash_lasterrorstr);
+	if (verbose)
+            putchar('\n');
+    }
+
+    restoreint();
+}

--- a/cmd.h
+++ b/cmd.h
@@ -19,5 +19,6 @@ void cmd_format(int, int);
 void cmd_restore(int, int, char*, int);
 void cmd_dump(int, int, char*, int);
 void cmd_write(int, int, int, int, char**);
+void cmd_read(int, int, int, char**);
 
 #endif /* EMS_CMD_H */

--- a/cmd.h
+++ b/cmd.h
@@ -16,6 +16,8 @@ void restoreint();
 void cmd_title(int);
 void cmd_delete(int, int, int, char**);
 void cmd_format(int, int);
+void cmd_restore(int, int, char*, int);
+void cmd_dump(int, int, char*, int);
 void cmd_write(int, int, int, int, char**);
 
 #endif /* EMS_CMD_H */

--- a/config.sh
+++ b/config.sh
@@ -46,17 +46,15 @@ then
     exit 1
 fi
 
-#tmp_conf=`mktemp` || exit
-tmp_conf=`mktemp 2>/dev/null || mktemp -t 'emsflasher'` || exit
+tmpd=`mktemp -d 2>/dev/null || mktemp -d -t 'ems-flasher'` || exit
+trap 'rm -r "$tmpd"' EXIT
 
-cat > "$tmp_conf" <<EOT
+cat > "$tmpd/conf" <<EOT
 #ifndef EMS_CONFIG_H
 #define EMS_CONFIG_H
 EOT
 
-#tmp_c=`mktemp` || exit
-tmp_c=`mktemp 2>/dev/null || mktemp -t 'emsflasher'` || exit
-cat <<EOT > "$tmp_c.c"
+cat <<EOT > "$tmpd/test_libpthread.c"
 #include <stdio.h>
 #include <libusb.h>
 int main() {
@@ -64,22 +62,32 @@ int main() {
 	return 0;
 }
 EOT
-$CC $CFLAGS $libusb_cflags "$tmp_c.c" $libusb_ldflags -o "$tmp_c" || exit
+
 if
-    ldd "$tmp_c" | grep -q libpthread
+    ! $CC $CFLAGS $libusb_cflags "$tmpd/test_libpthread.c" $libusb_ldflags \
+        -o "$tmpd/test_libpthread" 2>"$tmpd/err"
+then
+    cat "$tmpd/err" >&2
+    exit 1
+fi
+
+ldd "$tmpd/test_libpthread" > "$tmpd/lddout" || exit
+
+if
+    grep -q libpthread "$tmpd/lddout"
 then
     echo "$libusb seems to use libpthread"
     pthread_ldflags="-lpthread"
-    echo "#define USE_PTHREAD" >> "$tmp_conf"
+    echo "#define USE_PTHREAD" >> "$tmpd/conf"
 else
     echo "$libusb doesn't seem to use libpthread. Fine."
 fi
 
-echo "#define MENUDIR \"$DATADIR\"" >> "$tmp_conf"
+echo "#define MENUDIR \"$DATADIR\"" >> "$tmpd/conf"
 
-echo '#endif' >> "$tmp_conf"
+echo '#endif' >> "$tmpd/conf"
 if ! cmp -s "$tmp_conf" config.h; then
-    mv "$tmp_conf" config.h
+    mv "$tmpd/conf" config.h
 fi
 
 cat > Makefile << EOT

--- a/ems-flasher.1
+++ b/ems-flasher.1
@@ -1,4 +1,4 @@
-.Dd April 16, 2017
+.Dd August 18, 2017
 .Dt EMS-FLASHER 1
 .Os
 .Sh NAME
@@ -13,6 +13,9 @@
 The
 .Nm
 utility reads data from or writes data to a EMS 64 Mbit USB Game Boy cartridge.
+See
+.Sx "THE EMS CARTRIDGE"
+for details about the cartridge itself.
 .Sh OPTIONS
 .Bl -tag -width x
 .It Fl Fl page Ar num
@@ -41,18 +44,10 @@ Display more information and a progress bar.
 .Sh COMMANDS
 .Bl -tag -width x
 .It Fl Fl write Ar romfile ...
-Add ROMs to the selected page.
-.br
-If you intend to use the card on a Super Game Boy or a Game Boy Color,
-you should isolate, resp., the Super Game Boy ROMs or the Game Boy Color ROMS
-on a same page and put the other ROMs on the other page.
-E.g. if you own a Game Boy Color, you could put all the Game Boy Color ROMs in
-page 1 and the Super Game Boy and Classic Game Boy ROMs in the other.
-Use
-.Fl Fl force
-to write ROMs from different models on the same page.
-.It Fl Fl read Ar bank:romfile ...
-Read ROMs from the selected page.
+Add ROMs to the selected page. See
+.Sx MIXING ROMS OF DIFFERENT MODELS
+for the rules to follow to mix ROMs targetting different models of the
+console.
 .It Fl Fl dump Ar file
 Backup an entire flash page or the SRAM to a file. The source can be
 selected by
@@ -82,6 +77,52 @@ and
 ROMs are identified by the number of their first bank, which is printed by the
 .Fl Fl title
 command.
+.Sh THE EMS CARTRIDGE
+.Pp
+The cartridge is composed of 8 MB (megabytes) of flash memory,
+128 KB (kilobytes) of
+static RAM that is backed up by a battery and of a MBC5-like memory controller.
+.Pp
+The flash memory is splitted into two pages of 4 MB (megabytes) each.
+128 ROMs of 32 KB can fit in a page.
+.Pp
+The static RAM is not paged and there is no partitioning mechanism that would
+allow it to be shared by multiple ROMs. That means when a ROM save data to
+the SRAM, it will likely corrupt previous data placed by another ROM.
+.Pp
+Many ROMs should work flawlessly but others may experiment crashes or other
+issues due to the fact that the memory controller of the EMS cartridge doesn't
+emulate the MBC5 perfectly and that the chip is not fully backward-compatible
+with previous versions.
+.Pp
+See
+.Lk http://blog.gg8.se/gameboyprojects/week09/EMS_FAQ.txt
+for details on programming the memory controler of the EMS cartridge.
+.Sh MIXING ROMS OF DIFFERENT MODELS
+.Pp
+Each ROM has a mode set in their header to signal a Game Boy Color
+or a Super Game Boy console
+if it must be run in compatibility mode, i.e., with the behaviours of an
+original Game Boy or with the enhancements offered by the console (wich present
+some incompatibilities with the original console).
+.Pp
+On the EMS cartridge, only one mode can be set per page. All ROMs of a page
+will be run with that mode regardless the mode of the ROMs.
+.Pp
+The mode is set at the time of writing the first ROM of an empty page.
+.Pp
+The original Game Boy disregard this flag and ROMs can be mixed and run as
+long as they are compatible with the console.
+However, on other models,
+you can't mix, on the same page, ROMs targetting the original Game Boy
+with others supporting enhancements of the host console.
+In other words, if you intend to use the card on a Super Game Boy or
+a Game Boy Color, you should isolate, resp., the Super Game Boy ROMs or
+the Game Boy Color ROMS on a same page and put the other ROMs on the other page.
+E.g. if you own a Game Boy Color, you could put all the Game Boy Color ROMs in
+page 1 and the Super Game Boy and Classic Game Boy ROMs in the other
+(using
+.Fl Fl force ) .
 .Sh EXIT STATUS
 .Ex -std ems-flasher
 .Sh EXAMPLES

--- a/ems-flasher.1
+++ b/ems-flasher.1
@@ -1,4 +1,4 @@
-.Dd October 18, 2013
+.Dd April 16, 2017
 .Dt EMS-FLASHER 1
 .Os
 .Sh NAME
@@ -6,69 +6,99 @@
 .Nd utility to flash EMS 64 Mbit USB Game Boy cartridge
 .Sh SYNOPSIS
 .Nm
-.Fl Fl read\ \&
-.Op Fl Fl bank Ar num
-.Op Fl Fl blocksize Ar size
-.Op Fl Fl rom
-.Op Fl Fl save
-.Op Fl Fl verbose
-.Ar romfile
-.Nm
-.Fl Fl write
-.Op Fl Fl bank Ar num
-.Op Fl Fl blocksize Ar size
-.Op Fl Fl rom
-.Op Fl Fl save
-.Op Fl Fl verbose
-.Ar romfile
-.Nm
-.Fl Fl title
+.Op Ar option ...
+.Ar command
+.Op Ar arg ...
 .Sh DESCRIPTION
 The
 .Nm
 utility reads data from or writes data to a EMS 64 Mbit USB Game Boy cartridge.
-One of the following flags is required:
+.Sh OPTIONS
 .Bl -tag -width x
-.It Fl Fl read
-read ROM/SRAM from cart
-.It Fl Fl write
-write ROM/SRAM to cart
-.It Fl Fl header
-print header of ROMs on cart to standard output
-.El
-.Pp
-When in write or read mode,
-.Nm
-will automatically choose ROM versus SRAM based on the filename:
-if the filename ends in
-.Dq .sav ,
-SRAM is assumed.
-.Pp
-In read or write mode, the available options are as follows:
-.Bl -tag -width Ds
-.It Fl Fl bank
-Select cart bank (1 or 2).
-.It Fl Fl blocksize Ar size
-Specify the blocksize in bytes.
-The default is 4096 for read, 32 for write.
+.It Fl Fl page Ar num
+Select cart page (1 or 2). Page 1 will be selected if this option is not
+provided.
+.It Fl Fl force
+Used with
+.Fl Fl write .
+Force writing ROMs from different models of Game Boy on the same page.
 .It Fl Fl rom
-Force read/write of Flash ROM.
+Force
+.Fl Fl dump
+and
+.Fl Fl restore
+to use the flash memory. This is the default unless the filename ends with
+.Dq .sav .
 .It Fl Fl save
-Force read/write of SRAM.
+Force
+.Fl Fl dump
+and
+.Fl Fl restore
+to use the Save RAM.
 .It Fl Fl verbose
-Display more information.
+Display more information and a progress bar.
 .El
+.Sh COMMANDS
+.Bl -tag -width x
+.It Fl Fl write Ar romfile ...
+Add ROMs to the selected page.
+.br
+If you intend to use the card on a Super Game Boy or a Game Boy Color,
+you should isolate, resp., the Super Game Boy ROMs or the Game Boy Color ROMS
+on a same page and put the other ROMs on the other page.
+E.g. if you own a Game Boy Color, you could put all the Game Boy Color ROMs in
+page 1 and the Super Game Boy and Classic Game Boy ROMs in the other.
+Use
+.Fl Fl force
+to write ROMs from different models on the same page.
+.It Fl Fl read Ar bank:romfile ...
+Read ROMs from the selected page.
+.It Fl Fl dump Ar file
+Backup an entire flash page or the SRAM to a file. The source can be
+selected by
+.Fl Fl rom
+or
+.Fl Fl save .
+.It Fl Fl restore Ar file
+Restore a backup taken by
+.Fl Fl dump
+to flash or SRAM. The source can be
+selected by
+.Fl Fl rom
+or
+.Fl Fl save .
+.It Fl Fl title
+Print the content of the selected page.
+.It Fl Fl delete Ar bank ...
+Delete the specified ROMs.
+.It Fl Fl format
+Delete all ROMs of the selected page.
+.El
+.Pp
+For
+.Fl Fl read 
+and
+.Fl Fl delete ,
+ROMs are identified by the number of their first bank, which is printed by the
+.Fl Fl title
+command.
 .Sh EXIT STATUS
 .Ex -std ems-flasher
 .Sh EXAMPLES
-Write the ROM to the cart:
+Add a ROM to the cart:
 .Dl $ ems-flasher --write totally_legit_rom.gb
 .Pp
-Save the contents of bank 2 into a file; print some extra info:
-.Dl $ ems-flasher --verbose --bank 2 --read not_warez.gb
+Add several ROMs to the cart:
+.Dl $ ems-flasher --write copyright.gb infringement.gb
 .Pp
-Read the SRAM from bank 1:
-.Dl $ ems-flasher --read my_pokeymans.sav
+Save the contents of page 2 into a file; print some extra info:
+.Dl $ ems-flasher --verbose --page 2 --dump not_warez.gb
+.Pp
+Read the SRAM from page 1:
+.Dl $ ems-flasher --dump my_pokeymans.sav
+.Pp
+Read the ROM starting at bank 64 to a file:
+.Dl $ ems-flasher --read 64:totally_legit_rom.gb
 .Pp
 Print out the headers:
 .Dl $ ems-flasher --title

--- a/ems.c
+++ b/ems.c
@@ -45,6 +45,10 @@ static int find_ems_device(void) {
     int i = 0;
     int retval = 0;
 
+#define INSTALLUDEVMSG "Try running as root/sudo or update udev rules " \
+                       "(check Building and Installating instructions " \
+                       "in the README.md file for more info).\n"
+
     num_devices = libusb_get_device_list(NULL, &device_list);
     if (num_devices >= 0) {
         for (; i < num_devices; ++i) {
@@ -63,7 +67,7 @@ static int find_ems_device(void) {
                         fprintf(stderr, "Failed to open device (libusb error: %s).\n", libusb_error_name(retval));
 #ifdef __linux__                      
                         if (retval == LIBUSB_ERROR_ACCESS) {
-                            fprintf(stderr, "Try running as root/sudo or update udev rules (check the FAQ for more info).\n");
+                            fprintf(stderr, INSTALLUDEVMSG);
                         }
 #endif
                     }
@@ -74,7 +78,9 @@ static int find_ems_device(void) {
             }
         }
         if (i == num_devices) {
-            fprintf(stderr, "Could not find device, is it plugged in?\n");
+            fprintf(stderr, "Could not find device, is it plugged in?\n"
+                            "Or it's may be a permission issue. "
+                            INSTALLUDEVMSG);
         }
         libusb_free_device_list(device_list, 1);
         device_list = NULL;

--- a/flash.h
+++ b/flash.h
@@ -13,7 +13,9 @@ char flash_lasterrorstr[256];
 
 void flash_init(void (*)(int, ems_size_t), int (*)(void));
 void flash_setprogresscb(void (*)(int, ems_size_t));
+int flash_writef_to(int, ems_size_t, ems_size_t, char*);
 int flash_writef(ems_size_t, ems_size_t, char*);
+int flash_readf_from(int, char*, ems_size_t, ems_size_t);
 int flash_move(ems_size_t, ems_size_t, ems_size_t);
 int flash_read(int, ems_size_t, ems_size_t);
 int flash_write(ems_size_t, ems_size_t, int);

--- a/main.c
+++ b/main.c
@@ -281,7 +281,9 @@ int main(int argc, char **argv) {
     }
 
     // read the ROM and save it into the file
-    if (opts.mode == MODE_DUMP) {
+    if (opts.mode == MODE_READ) {
+        cmd_read(opts.bank, opts.verbose, opts.rem_argc, opts.rem_argv);
+    } else if (opts.mode == MODE_DUMP) {
         cmd_dump(opts.bank, opts.verbose, opts.file, space);
     } else if (opts.mode == MODE_RESTORE) {
         cmd_restore(opts.bank, opts.verbose, opts.file, space);

--- a/main.c
+++ b/main.c
@@ -55,29 +55,36 @@ options_t opts = {
  * Usage
  */
 void usage(char *name) {
-    printf("Usage: %s < --read | --write > [ --verbose ] <totally_legit_rom.gb> [<dontsteal.gb>]\n", name);
-    printf("       %s --delete BANK [BANK]...\n", name);
-    printf("       %s --format\n", name);
-    printf("       %s --title\n", name);
-    printf("       %s --version\n", name);
-    printf("       %s --help\n", name);
-    printf("Writes a ROM or SAV file to the EMS 64 Mbit USB flash cart\n\n");
-    printf("Options:\n");
-    printf("    --read                  read entire cart into file\n");
-    printf("    --write                 write ROM file(s) to cart\n");
-    printf("    --dump                  dump an entire page of SRAM or flash"
-                                        "to a file\n");
-    printf("    --restore               restore a dump taken by --dump\n");
-    printf("    --delete                delete ROMs with the specified bank numbers\n");
-    printf("    --format                delete all ROMs of the specified page\n");
-    printf("    --title                 title of the ROM in both banks\n");
-    printf("    --verbose               displays more information\n");
-    printf("    --page <num>            select cart page (1 or 2)\n");
-    printf("    --save                  force write to SRAM\n");
-    printf("    --rom                   force write to Flash ROM\n");
+    printf("Usage: %s [ OPTION... ] COMMAND [ ARG... ]\n", name);
     printf("\n");
-    printf("You MUST supply exactly one of --read, --write, or --title\n");
-    printf("Reading or writing with a file ending in .sav will write to SRAM.\n");
+    printf("Options:\n");
+    printf(" --force              force writing of ROMs from different models "
+           "of Game Boy\n");
+    printf(" --verbose            displays more information and a progress "
+           "bar\n");
+    printf(" --page PAGE          select cart page (1 or 2).\n");
+    printf(" --save               force restore/dump to/from SRAM\n");
+    printf(" --rom                force restore/dump to/from Flash\n");
+    printf("\n");
+    printf("Commands:\n");
+    printf(" --read BANK:FILE...  read ROMs with the specified banks to "
+           "files\n");
+    printf(" --write FILE...      write ROM file(s) to cart\n");
+    printf(" --dump               dump an entire page of Flash or SRAM to "
+           "a file\n");
+    printf(" --restore            restore an entire page of Flash or SRAM "
+           "to a file\n");
+    printf(" --delete BANK...     delete ROMs with the specified banks\n");
+    printf(" --format             delete all ROMs of the specified page\n");
+    printf(" --title              list page content\n");
+    printf(" --version            print version number\n");
+    printf(" --help               show this help\n");
+    printf("\n");
+    printf("You MUST supply exactly one command.\n");
+    printf("ROMs specified in --read and --delete are designated by the bank "
+           "number printed\nby the --title command.\n");
+    printf("Dumping or restoring with a file ending in .sav will read/write to "
+           "SRAM.\n");
     printf("To select between ROM and SRAM, use ONE of the --save / --rom options.\n");
     printf("\n");
     printf("Written by Mike Ryan <mikeryan@lacklustre.net> and others\n");

--- a/main.c
+++ b/main.c
@@ -20,6 +20,8 @@ const int limits[3] = {0, PAGESIZE, SRAMSIZE};
 #define MODE_TITLE  3
 #define MODE_DELETE 4
 #define MODE_FORMAT 5
+#define MODE_RESTORE 6
+#define MODE_DUMP 7
 
 /* options */
 typedef struct _options_t {
@@ -63,6 +65,9 @@ void usage(char *name) {
     printf("Options:\n");
     printf("    --read                  read entire cart into file\n");
     printf("    --write                 write ROM file(s) to cart\n");
+    printf("    --dump                  dump an entire page of SRAM or flash"
+                                        "to a file\n");
+    printf("    --restore               restore a dump taken by --dump\n");
     printf("    --delete                delete ROMs with the specified bank numbers\n");
     printf("    --format                delete all ROMs of the specified page\n");
     printf("    --title                 title of the ROM in both banks\n");
@@ -74,9 +79,6 @@ void usage(char *name) {
     printf("You MUST supply exactly one of --read, --write, or --title\n");
     printf("Reading or writing with a file ending in .sav will write to SRAM.\n");
     printf("To select between ROM and SRAM, use ONE of the --save / --rom options.\n");
-    printf("\n");
-    printf("Advanced options:\n");
-    printf("    --blocksize <size>      bytes per block (default: 4096 read, 32 write)\n");
     printf("\n");
     printf("Written by Mike Ryan <mikeryan@lacklustre.net> and others\n");
     printf("See web site for more info:\n");
@@ -98,6 +100,8 @@ void get_options(int argc, char **argv) {
             {"verbose", 0, 0, 'v'},
             {"read", 0, 0, 'r'},
             {"write", 0, 0, 'w'},
+            {"restore", 0, 0, 'e'},
+            {"dump", 0, 0, 'u'},
             {"title", 0, 0, 't'},
             {"delete", 0, 0, 'd'},
             {"format", 0, 0, 'f'},
@@ -134,6 +138,14 @@ void get_options(int argc, char **argv) {
             case 'w':
                 if (opts.mode != 0) goto mode_error;
                 opts.mode = MODE_WRITE;
+                break;
+            case 'e':
+                if (opts.mode != 0) goto mode_error;
+                opts.mode = MODE_RESTORE;
+                break;
+            case 'u':
+                if (opts.mode != 0) goto mode_error;
+                opts.mode = MODE_DUMP;
                 break;
             case 't':
                 if (opts.mode != 0) goto mode_error;
@@ -199,7 +211,8 @@ void get_options(int argc, char **argv) {
             printf("Error: you must provide bank numbers\n");
             usage(argv[0]);
         }
-    } else if (opts.mode == MODE_WRITE || opts.mode == MODE_READ) {
+    } else if (opts.mode == MODE_WRITE || opts.mode == MODE_READ ||
+               opts.mode == MODE_RESTORE || opts.mode == MODE_DUMP) {
         // user didn't give a filename
         if (optind >= argc) {
             printf("Error: you must provide an %s filename\n", opts.mode == MODE_READ ? "output" : "input");
@@ -211,14 +224,15 @@ void get_options(int argc, char **argv) {
 
         // set a default blocksize if the user hasn't given one
         if (opts.blocksize == 0)
-            opts.blocksize = opts.mode == MODE_READ ? BLOCKSIZE_READ : BLOCKSIZE_WRITE;
+            opts.blocksize = (opts.mode == MODE_READ
+                || opts.mode == MODE_DUMP)? BLOCKSIZE_READ : BLOCKSIZE_WRITE;
     }
 
     return;
 
 mode_error:
-    printf("Error: must supply exactly one of --read, --write, --delete, "
-        "--format or --title\n");
+    printf("Error: must supply exactly one of --read, --write, --dump, "
+           "--restore, --delete, --format or --title\n");
     usage(argv[0]);
 
 mode_error2:
@@ -245,16 +259,10 @@ int main(int argc, char **argv) {
         printf("claimed EMS cart\n");
 
     // we'll need a buffer one way or another
-    int blocksize = opts.blocksize;
-    uint32_t offset = 0;
     uint32_t base = opts.bank * PAGESIZE;
     if (opts.verbose)
         printf("base address is 0x%X\n", base);
     
-    unsigned char *buf = malloc(blocksize);
-    if (buf == NULL)
-        err(1, "malloc");
-
     // determine what we're reading/writing from/to
     int space = opts.space;
     if (space == 0 && opts.file != NULL) {
@@ -273,60 +281,11 @@ int main(int argc, char **argv) {
     }
 
     // read the ROM and save it into the file
-    if (opts.mode == MODE_READ) {
-        FILE *save_file = fopen(opts.file, "w");
-        if (save_file == NULL)
-            err(1, "Can't open %s for writing", opts.file);
-
-        if (opts.verbose && space == FROM_ROM)
-            printf("Saving ROM into %s\n", opts.file);
-        else if (opts.verbose)
-            printf("Saving SAVE into %s\n", opts.file);
-
-        while ((offset + blocksize) <= limits[space]) {
-            r = ems_read(space, offset + base, buf, blocksize);
-            if (r != blocksize) {
-                warnx("can't read %d bytes at offset %u\n", blocksize, offset);
-                return 1;
-            }
-
-            r = fwrite(buf, blocksize, 1, save_file);
-            if (r != 1)
-                err(1, "can't write %d bytes into file at offset %u", blocksize, offset);
-
-            offset += blocksize;
-        }
-
-        fclose(save_file);
-
-        if (opts.verbose)
-            printf("Successfully wrote %u bytes into %s\n", offset, opts.file);
-    }
-
-    // write ROM in the file to bank 1
-    else if (opts.mode == MODE_WRITE && space == TO_SRAM) {
-        FILE *write_file = fopen(opts.file, "r");
-        if (write_file == NULL)
-            err(1, "Can't open SAVE file %s", opts.file);
-
-        if (opts.verbose)
-            printf("Writing SAVE file %s\n", opts.file);
-
-        while ((offset + blocksize) <= limits[space] && fread(buf, blocksize, 1, write_file) == 1) {
-            r = ems_write(space, offset + base, buf, blocksize);
-            if (r != blocksize) {
-                warnx("can't write %d bytes at offset %u", blocksize, offset);
-                return 1;
-            }
-
-            offset += blocksize;
-        }
-
-        fclose(write_file);
-
-        if (opts.verbose)
-            printf("Successfully wrote %u from %s\n", offset, opts.file);
-    } else if (opts.mode == MODE_WRITE && space == TO_ROM) {
+    if (opts.mode == MODE_DUMP) {
+        cmd_dump(opts.bank, opts.verbose, opts.file, space);
+    } else if (opts.mode == MODE_RESTORE) {
+        cmd_restore(opts.bank, opts.verbose, opts.file, space);
+    } else if (opts.mode == MODE_WRITE) {
         cmd_write(opts.bank, opts.verbose, opts.force, opts.rem_argc, opts.rem_argv);
     } else if (opts.mode == MODE_DELETE) {
         cmd_delete(opts.bank, opts.verbose, opts.rem_argc, opts.rem_argv);
@@ -341,9 +300,6 @@ int main(int argc, char **argv) {
     // should never reach here
     else
         errx(1, "Unknown mode %d, file a bug report", opts.mode);
-
-    // belt and suspenders
-    free(buf);
 
     return 0;
 }

--- a/main.c
+++ b/main.c
@@ -72,7 +72,7 @@ void usage(char *name) {
     printf("    --format                delete all ROMs of the specified page\n");
     printf("    --title                 title of the ROM in both banks\n");
     printf("    --verbose               displays more information\n");
-    printf("    --bank <num>            select cart bank (1 or 2)\n");
+    printf("    --page <num>            select cart page (1 or 2)\n");
     printf("    --save                  force write to SRAM\n");
     printf("    --rom                   force write to Flash ROM\n");
     printf("\n");
@@ -107,6 +107,7 @@ void get_options(int argc, char **argv) {
             {"format", 0, 0, 'f'},
             {"blocksize", 1, 0, 's'},
             {"bank", 1, 0, 'b'},
+            {"page", 1, 0, 'b'},
             {"save", 0, 0, 'S'},
             {"rom", 0, 0, 'R'},
             {"force", 0, 0, 'F'},

--- a/progress.c
+++ b/progress.c
@@ -41,40 +41,13 @@ progress_newline(void) {
  *     (see flash.c, under "Progress status").
  */
 void
-progress_start(struct updates *updates) {
-    struct update *u;
-
+progress_start(struct progress_totals totals) {
     crprinted = 0;
 
-    updates_foreach(updates, u) {
-        switch (u->cmd) {
-        case UPDATE_CMD_WRITEF:
-            if (u->update_writef_dstofs%ERASEBLOCKSIZE == 0)
-                progress_type[PROGRESS_ERASE].total += (u->update_writef_size +
-                    ERASEBLOCKSIZE-1)/ERASEBLOCKSIZE;
-            progress_type[PROGRESS_WRITEF].total += u->update_writef_size;
-            break;
-        case UPDATE_CMD_MOVE:
-            if (u->update_move_dstofs%ERASEBLOCKSIZE == 0)
-                progress_type[PROGRESS_ERASE].total += (u->update_move_size +
-                     ERASEBLOCKSIZE-1)/ERASEBLOCKSIZE;
-            progress_type[PROGRESS_WRITE].total += u->update_move_size;
-            progress_type[PROGRESS_READ].total += u->update_move_size;
-            break;
-        case UPDATE_CMD_WRITE:
-            if (u->update_write_dstofs%ERASEBLOCKSIZE == 0)
-                progress_type[PROGRESS_ERASE].total += (u->update_write_size +
-                    ERASEBLOCKSIZE-1)/ERASEBLOCKSIZE;
-            progress_type[PROGRESS_WRITE].total += u->update_write_size;
-            break;
-        case UPDATE_CMD_READ:
-            progress_type[PROGRESS_READ].total += u->update_read_size;
-            break;
-        case UPDATE_CMD_ERASE:
-            progress_type[PROGRESS_ERASE].total++;
-            break;
-        }
-    }
+    progress_type[PROGRESS_ERASE].total = totals.erase;
+    progress_type[PROGRESS_WRITEF].total = totals.writef;
+    progress_type[PROGRESS_WRITE].total = totals.write;
+    progress_type[PROGRESS_READ].total = totals.read;
 
     for (int i = 0; i < PROGRESS_TYPESNB; i++) {
         progress_type[i].remain = progress_type[i].total;

--- a/progress.h
+++ b/progress.h
@@ -9,8 +9,12 @@ enum {
     PROGRESS_TYPESNB
 };
 
+struct progress_totals {
+    int erase, writef, write, read;
+};
+
 void progress_newline(void);
-void progress_start(struct updates*);
+void progress_start(struct progress_totals);
 void progress(int, ems_size_t);
 
 #endif /* EMS_PROGRESS_H */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -4,15 +4,33 @@ ALL = test-flash1 test-flash2 test-flash3 test-flash4 test-updates test-insertup
 
 all: $(ALL)
 
+FLASH1_OBJS = test-flash1.o test.o common.o ../flash.o
+test-flash1: $(FLASH1_OBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(FLASH1_OBJS)
+
+FLASH2_OBJS = test-flash2.o test.o common.o ../flash.o
+test-flash2: $(FLASH2_OBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(FLASH2_OBJS)
+
+FLASH3_OBJS = test-flash3.o test.o common.o ../flash.o
+test-flash3: $(FLASH3_OBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(FLASH3_OBJS)
+
+FLASH4_OBJS = test-flash4.o test.o common.o ../flash.o ../progress.o
+test-flash4: $(FLASH4_OBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(FLASH4_OBJS)
+
+UPDATES_OBJS = test-updates.o test.o common.o ../updates.o
+test-updates: $(UPDATES_OBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(UPDATES_OBJS)
+
+INSERTUPDATE_OBJS = test-insertupdate.o ../insert.o ../update.o
+test-insertupdate: $(INSERTUPDATE_OBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(INSERTUPDATE_OBJS)
+
 ../flash.o ../progress.o ../updates.o ../insert.o ../update.o:
 	@echo '$@ missing. Please build ems-flasher or ems-flasher-file.' >&2
 	@exit 1
-
-test-flash1 test-flash2 test-flash3 test-flash4 test-updates: test.o common.o
-test-updates: ../updates.o
-test-flash1 test-flash2 test-flash3 test-flash4: ../flash.o
-test-flash4: ../progress.o
-test-insertupdate: ../insert.o ../update.o
 
 test: $(ALL)
 	prove ./test-flash[1234] ./test-updates ./test-idu.sh 2>/dev/null

--- a/tests/test-idu.sh
+++ b/tests/test-idu.sh
@@ -80,7 +80,7 @@ testdefrag() {
     )
 
     if [ $freetotal -eq 0 ]; then
-        continue
+        return 0
     fi
 
     size=$((freerommaxsize*2))

--- a/updateheader.sh
+++ b/updateheader.sh
@@ -6,6 +6,7 @@
 #
 # Used in the Makefile when generating the menu files.
 
+unset color super
 while getopts "cs" opt; do
     case $opt in
     c)  color=1;;
@@ -15,12 +16,12 @@ done
 
 # need to do some magic to make this portable to OS X and Linux
 AWK="awk"
-if which gawk > /dev/null; then
+if which gawk >/dev/null 2>&1; then
     AWK="gawk"
 fi
 
 OD="od"
-if which god > /dev/null; then
+if which god >/dev/null 2>&1; then
     OD="god"
 fi
 

--- a/updateheader.sh
+++ b/updateheader.sh
@@ -24,7 +24,9 @@ if which god > /dev/null; then
     OD="god"
 fi
 
-$OD -v -Ad -tu1 -w1 | LC_ALL=C $AWK -vcolor=$color -vsuper=$super '
+$OD -v -Ad -tu1 |
+    $AWK '{ o=0; for (i = 2; i <= NF; i++) print $1 + o++, $i }' |
+        LC_ALL=C $AWK -vcolor=$color -vsuper=$super '
 BEGIN {
     split( \
         " 206 237 102 102 204  13   0  11   3 115   0 131   0  12   0  13" \
@@ -32,8 +34,6 @@ BEGIN {
         " 187 187 103  99 110  14 236 204 221 220 153 159 187 185  51  62",
         logo)
 }
-
-$2 == "" {next}
 
 { out = $2 }
 


### PR DESCRIPTION
Hi all and @mikeryan ,

I've implemented a new version of the --read command able to read individual ROMs as well as --dump and --restore commands to dump/restore the entire flash and sram.

I've updated the documentation: the README, main.c and the man page from which you could learn about the new commands.  English is not my native language so there're probably some mistakes.

Also, I've replaced the --bank option by --page. --bank is still available as a hidden option though. And --blocksize is still available but is not documented anymore has it has no effect.

Regarding broken backward compatibility:
  --read and --write can't be used to dump/restore the entire flash or sram anymore. --dump and --restore should be used for these purposes.