### PR TITLE
config.sh improvement and fixed compile warning

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -91,7 +91,22 @@ then
     exit 1
 fi
 
-ldd "$tmpd/test_libpthread" > "$tmpd/lddout" || exit
+
+# detect and use either ldd (linux) or otool (macOS)
+if 
+    command -v ldd >/dev/null 2>&1
+then
+    LDD=ldd
+elif
+    command -v otool >/dev/null 2>&1
+then
+    LDD="otool -L"
+else
+    echo "System doesn't have ldd or otool... exiting."
+    exit 
+fi
+
+$LDD "$tmpd/test_libpthread" > "$tmpd/lddout" || exit
 
 if
     grep -q libpthread "$tmpd/lddout"


### PR DESCRIPTION
ldd isn't available on macOS, but otool is and does the same thing. I added some code to config.sh to detect and use either ldd or otool instead of always using ldd.

I also fixed a bug in cmd.c where an unsigned variable was being assigned -1 and checked greater-than-or-equal-to zero, which was a tautology. Fixing this removed a compile warning. I added a variable that's set to 1 when the error occurs, and used it wherever the unsigned variable was being checked for  ">= 0".